### PR TITLE
Use raw pinning to prevent mismatches in `buttons[pin]`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ module.exports = function (pins, options) {
   pins.forEach(function (pin) {
     buttonSetup(pin);
   });
+  
+  gpio.setMode(gpio.MODE_BCM);
 
   // watch for gpio change events
   gpio.on('change', gpioChange);


### PR DESCRIPTION
Otherwise no events will actually emit.